### PR TITLE
Fixes to print.eventlog

### DIFF
--- a/R/print.eventlog.R
+++ b/R/print.eventlog.R
@@ -6,7 +6,7 @@
 
 
 print.eventlog <- function(x, ...) {
-       nev <- n_events()
+       nev <- n_events(x)
         cat("Log of", nev, ngettext(nev, "event", "events"), "consisting of:\n")
         if(nev < 250000) {
                 ntr <- nrow(trace_list(x))

--- a/R/print.eventlog.R
+++ b/R/print.eventlog.R
@@ -7,21 +7,21 @@
 
 print.eventlog <- function(x, ...) {
        nev <- n_events()
-        cat("Log of", nev, ngettext(nev, "event" "events"), "consisting of:\n")
+        cat("Log of", nev, ngettext(nev, "event", "events"), "consisting of:\n")
         if(nev < 250000) {
                 ntr <- nrow(trace_list(x))
-                cat(ntr, ngettext(ntr, "trace" "traces"), "\n")
+                cat(ntr, ngettext(ntr, "trace", "traces"), "\n")
         }
         ncs <- n_cases(x)
-        cat(ncs, ngettext(ncs, "case" "cases"), "\n")
+        cat(ncs, ngettext(ncs, "case", "cases"), "\n")
         nai <- n_activity_instances(x)
         nac <- n_activities(x)
         cat(
-                nai, ngettext(nai, "instance" "instances"), "of", 
-                nac, ngettext(nac, "activity" "activities"), "\n"
+                nai, ngettext(nai, "instance", "instances"), "of", 
+                nac, ngettext(nac, "activity", "activities"), "\n"
         )
         nrs <- n_resources(x)
-        cat(nrs, ngettext(nrs, "resource" "resources"), "\n")
+        cat(nrs, ngettext(nrs, "resource", "resources"), "\n")
         timestamps <- x[[timestamp(x)]]
         cat(
                 "Events occurred from", format(min(timestamps)), 

--- a/R/print.eventlog.R
+++ b/R/print.eventlog.R
@@ -25,7 +25,7 @@ print.eventlog <- function(x, ...) {
         timestamps <- x[[timestamp(x)]]
         cat(
                 "Events occurred from", format(min(timestamps)), 
-                "until", format(max(timestamps)), "\n"
+                "until", format(max(timestamps)), "\n", "\n"
         )
         cat("Variables were mapped as follows:\n")
         print(mapping(x))


### PR DESCRIPTION
Fixes #17 / latest commit issues
- Added commas to the different `ngettext` statements
- Added variable x to `n_events()` function call