### PR TITLE
Don't ungroup an event log that is not grouped 

### DIFF
--- a/R/group_by.eventlog.R
+++ b/R/group_by.eventlog.R
@@ -110,12 +110,15 @@ ungroup_eventlog <- function(eventlog) {
 #' @describeIn ungroup_eventlog Remove groups from event log
 #' @export
 ungroup_eventlog.eventlog <- function(eventlog) {
-	eventlog %>%
-		as.data.frame %>%
-		re_map(mapping(eventlog))
+	if (is_grouped_eventlog(eventlog)) {
+		eventlog %>%
+			as.data.frame %>%
+			re_map(mapping(eventlog))
+	} else {
+		eventlog
+	}
 }
 
-
-
-
-
+is_grouped_eventlog <- function(eventlog) {
+	"grouped_eventlog" %in% class(eventlog)
+}

--- a/R/re_map.R
+++ b/R/re_map.R
@@ -1,6 +1,6 @@
 #' @title Re map
 #'
-#' @description Construct and eventlog using an existing mapping.
+#' @description Construct an eventlog using an existing mapping.
 #'
 #' @param eventlog The event log data to be used.
 #'


### PR DESCRIPTION
Ungrouping / re-mapping can be quite costly as it is implemented now.