### PR TITLE
Avoid expensive validation of event log properties on re-map

### DIFF
--- a/R/group_by.eventlog.R
+++ b/R/group_by.eventlog.R
@@ -118,7 +118,3 @@ ungroup_eventlog.eventlog <- function(eventlog) {
 		eventlog
 	}
 }
-
-is_grouped_eventlog <- function(eventlog) {
-	"grouped_eventlog" %in% class(eventlog)
-}

--- a/R/n_cases.R
+++ b/R/n_cases.R
@@ -14,10 +14,8 @@ n_cases <- function(eventlog) {
 
 #' @describeIn n_cases Count number of cases for eventlog
 #' @export
-
 n_cases.eventlog <- function(eventlog) {
-	colnames(eventlog)[colnames(eventlog) == case_id(eventlog)] <- "case_classifier"
-	return(length(unique(eventlog$case_classifier)))
+	return(length(unique(eventlog[[case_id(eventlog)]])))
 }
 
 #' @describeIn n_cases Count number of cases for grouped eventlog

--- a/R/print.eventlog.R
+++ b/R/print.eventlog.R
@@ -10,7 +10,7 @@ print.eventlog <- function(x, ...) {
 
         cat("Log of", nev, ngettext(nev, "event", "events"), "consisting of:\n")
         if(nev < 250000) {
-                ntr <- nrow(trace_list(x))
+                ntr <- n_traces(x)
                 cat(ntr, ngettext(ntr, "trace", "traces"), "\n")
         }
         ncs <- n_cases(x)
@@ -18,14 +18,14 @@ print.eventlog <- function(x, ...) {
         nai <- n_activity_instances(x)
         nac <- n_activities(x)
         cat(
-                nai, ngettext(nai, "instance", "instances"), "of", 
+                nai, ngettext(nai, "instance", "instances"), "of",
                 nac, ngettext(nac, "activity", "activities"), "\n"
         )
         nrs <- n_resources(x)
         cat(nrs, ngettext(nrs, "resource", "resources"), "\n")
         timestamps <- x[[timestamp(x)]]
         cat(
-                "Events occurred from", format(min(timestamps)), 
+                "Events occurred from", format(min(timestamps)),
                 "until", format(max(timestamps)), "\n", "\n"
         )
         cat("Variables were mapped as follows:\n")
@@ -37,7 +37,7 @@ print.eventlog <- function(x, ...) {
 #' @export
 print.grouped_eventlog <- function(x, ...) {
 	groups <- groups(x)
-	x <- eventlog(x)
+	x <- eventlog(x, validate = FALSE, order = "sorted")
 	cat(glue("# Groups: [{paste(groups, collapse = \", \")}]"))
 	cat("\nGrouped ")
 	NextMethod(x)

--- a/R/re_map.R
+++ b/R/re_map.R
@@ -16,5 +16,6 @@ re_map <- function(eventlog, eventlog_mapping) {
 			lifecycle_id = eventlog_mapping$lifecycle_identifier,
 			timestamp = eventlog_mapping$timestamp_identifier,
 			resource_id = eventlog_mapping$resource_identifier,
-			order = ".order")
+			order = ".order",
+			validate = FALSE) # assumes that data is OK upon for `re_map`
 }

--- a/R/summary.eventlog.R
+++ b/R/summary.eventlog.R
@@ -46,6 +46,6 @@ summary.eventlog <- function(object, ...){
 #' @export
 
 summary.grouped_eventlog <- function(object, ...) {
-	object <- eventlog(object)
+	object <- eventlog(object, validate = FALSE)
 	NextMethod(object)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -10,3 +10,11 @@ activity_instance_id_ <- function(eventlog) sym(activity_instance_id(eventlog))
 resource_id_ <- function(eventlog) sym(resource_id(eventlog))
 timestamp_ <- function(eventlog) sym(timestamp(eventlog))
 lifecycle_id_ <- function(eventlog) sym(lifecycle_id(eventlog))
+
+is_eventlog <- function(eventlog) {
+	"eventlog" %in% class(eventlog)
+}
+
+is_grouped_eventlog <- function(eventlog) {
+	"grouped_eventlog" %in% class(eventlog)
+}


### PR DESCRIPTION
I noted that there are some validation actions when creating an event log from a data frame. These are also done unnecessarily each time `re_map` is called. For large logs or lots of operation this can lead to considerable overhead.

This pull request introduces a new parameter `validate`, which can be used to avoid validation when it is safe to do so. Also, it introduces a new choice for the ordering parameter so avoid re-ordering the log when that has already been done.

Finally, some very minor performance improving adjustments were done.