### PR TITLE
Improve trace_list and case_list performance

### DIFF
--- a/R/case_list.R
+++ b/R/case_list.R
@@ -28,7 +28,7 @@ case_list.eventlog <- function(eventlog){
 
 	cases <- cases[order(get(timestamp(eventlog)), get(".order")),
 				   list(trace = paste(get(activity_id(eventlog)), collapse = ",")),
-				   by = list(get(case_id(eventlog)))][,
+				   by = c(case_id(eventlog))][,
 				   	trace_id := as.numeric(factor(get("trace")))
 				   ]
 

--- a/R/trace_list.R
+++ b/R/trace_list.R
@@ -25,25 +25,25 @@ trace_list.eventlog <- function(eventlog){
 
 	eDT <- data.table::data.table(eventlog)
 
-	cases <- eDT[,
-				 list("timestamp_classifier" = min(get(timestamp(eventlog))), "min_order" = min(get(".order"))),
-				 by = list("A" = get(case_id(eventlog)), "B" = get(activity_instance_id(eventlog)), "C" = get(activity_id(eventlog)))]
-	cases <- cases[order(get("timestamp_classifier"), min_order),
-				   list(trace = paste(get("C"), collapse = ",")),
-				   by = list("CASE" = get("A"))]
-	cases <- cases %>% mutate(trace_id = as.numeric(factor(!!as.symbol("trace")))) %>%
-		rename(!!as.symbol(case_id(eventlog)) := "CASE")
+	# this is roughly 3x faster than grouping and relies on unique taking the first distinct value
+	# which corresponds to the event with the minimum timestamp and minimum .order
+  	data.table::setorderv(eDT, cols = c(case_id(eventlog), timestamp(eventlog), ".order"))
+	cases <- unique(eDT, by = c(case_id(eventlog), activity_instance_id(eventlog), activity_id(eventlog)))
+
+	cases <- cases[order(get(timestamp(eventlog)), get(".order")),
+				   list(trace = paste(get(activity_id(eventlog)), collapse = ",")),
+				   by = list(get(case_id(eventlog)))][,
+				   	trace_id := as.numeric(factor(get("trace")))
+				   ]
 
 	.N <- NULL
 	absolute_frequency <- NULL
 	relative_frequency <- NULL
 
-	casesDT <- data.table(cases)
-
-	traces <- casesDT[, .(absolute_frequency = .N), by = .(trace)]
+	traces <- cases[, .(absolute_frequency = .N), by = .(trace)]
 
 	traces <- traces[order(absolute_frequency, decreasing = T),relative_frequency:=absolute_frequency/sum(absolute_frequency)]
 	traces %>%
-		tbl_df
+		as_tibble
 
 }

--- a/R/trace_list.R
+++ b/R/trace_list.R
@@ -32,7 +32,7 @@ trace_list.eventlog <- function(eventlog){
 
 	cases <- cases[order(get(timestamp(eventlog)), get(".order")),
 				   list(trace = paste(get(activity_id(eventlog)), collapse = ",")),
-				   by = list(get(case_id(eventlog)))][,
+				   by = c(case_id(eventlog))][,
 				   	trace_id := as.numeric(factor(get("trace")))
 				   ]
 


### PR DESCRIPTION
By using unique instead of group_by and exploiting that we only want to retain the first event anyway it gets >3x faster:

```
> microbenchmark::microbenchmark(trace_list(sepsis), bupaR:::trace_list_old(sepsis), check = my_check)
Unit: milliseconds
                           expr      min       lq     mean   median       uq       max neval cld
             trace_list(sepsis) 226.1444 245.2599 255.9937 252.6813 260.3807  473.5033   100  a 
 bupaR:::trace_list_old(sepsis) 849.3789 889.9069 929.9324 908.7784 942.5075 1500.0939   100   b
```